### PR TITLE
adding eOS versions

### DIFF
--- a/upstream/elementaryos/luna
+++ b/upstream/elementaryos/luna
@@ -1,0 +1,1 @@
+ubuntu:precise


### PR DESCRIPTION
eOS 0.2 Luna (Ubuntu 12.04 Precise)
eOS 0.4 Loki (Ubuntu 16.04 Xenial)